### PR TITLE
remove set GOMAXPROCS  from main

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
+	"github.com/liujianping/scaffold/cmd"
 	"log"
 	"os"
-	"runtime"
-
-	"github.com/liujianping/scaffold/cmd"
 )
 
 func main() {
@@ -15,6 +13,5 @@ func main() {
 		}
 	}()
 
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	cmd.App().Run(os.Args)
 }


### PR DESCRIPTION
Begin of go1.5 Go programs run with GOMAXPROCS set to the number of cores available there is no need to set it
